### PR TITLE
Add PWA setup, error boundary, and lazy history

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MODELIA</title>
   </head>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "AI Studio",
+  "short_name": "AI Studio",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "AI image generation app",
+  "icons": [
+    {
+      "src": "/vite.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,14 @@
+const CACHE_NAME = 'ai-studio-cache-v1';
+const URLS = ['/', '/index.html'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((resp) => resp || fetch(event.request))
+  );
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useRef, useState } from 'react'
+import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import './App.css'
 import { mockGenerate, type GenerationResult } from './api'
+
+const History = lazy(() => import('./History'))
 
 const styleOptions = ['Editorial', 'Streetwear', 'Vintage']
 
@@ -136,8 +138,10 @@ function App() {
         />
       </div>
 
-      {preview && (
+      {preview ? (
         <img src={preview} alt="preview" className="max-h-60 object-contain" />
+      ) : (
+        <p className="text-gray-500">No preview available</p>
       )}
 
       <div>
@@ -233,35 +237,9 @@ function App() {
         </p>
       )}
 
-      {history.length > 0 && (
-        <div>
-          <h2 className="font-semibold mb-2">History</h2>
-          <ul className="space-y-2">
-            {history.map((item) => (
-              <li key={item.id}>
-                <button
-                  type="button"
-                  onClick={() => handleSelectHistory(item)}
-                  className="flex items-center gap-2 w-full text-left focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  <img
-                    src={item.imageUrl}
-                    alt="history item"
-                    className="w-16 h-16 object-cover"
-                  />
-                  <div>
-                    <p className="text-sm">{item.prompt}</p>
-                    <p className="text-xs text-gray-500">{item.style}</p>
-                    <p className="text-[10px] text-gray-400">
-                      {new Date(item.createdAt).toLocaleString()}
-                    </p>
-                  </div>
-                </button>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+      <Suspense fallback={<p>Loading history...</p>}>
+        <History history={history} onSelect={handleSelectHistory} />
+      </Suspense>
     </div>
   )
 }

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -1,0 +1,28 @@
+import { Component, type ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error) {
+    console.error(error)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <p role="alert">Something went wrong.</p>
+    }
+    return this.props.children
+  }
+}

--- a/src/History.tsx
+++ b/src/History.tsx
@@ -1,0 +1,44 @@
+import { memo } from 'react'
+import type { GenerationResult } from './api'
+
+interface Props {
+  history: GenerationResult[]
+  onSelect: (item: GenerationResult) => void
+}
+
+const History = memo(function History({ history, onSelect }: Props) {
+  if (history.length === 0) {
+    return <p className="text-gray-500">No history yet</p>
+  }
+  return (
+    <div>
+      <h2 className="font-semibold mb-2">History</h2>
+      <ul className="space-y-2">
+        {history.map((item) => (
+          <li key={item.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(item)}
+              className="flex items-center gap-2 w-full text-left focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <img
+                src={item.imageUrl}
+                alt="history item"
+                className="w-16 h-16 object-cover"
+              />
+              <div>
+                <p className="text-sm">{item.prompt}</p>
+                <p className="text-xs text-gray-500">{item.style}</p>
+                <p className="text-[10px] text-gray-400">
+                  {new Date(item.createdAt).toLocaleString()}
+                </p>
+              </div>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+})
+
+export default History

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,20 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { ErrorBoundary } from './ErrorBoundary'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 )
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch((err) => {
+      console.error('SW registration failed', err)
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- Add web manifest and simple service worker for offline caching
- Introduce ErrorBoundary and show empty states
- Lazy load History list with memoization for performance

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*


------
https://chatgpt.com/codex/tasks/task_e_68addb51474c832c89ee7b8e94edc6d0